### PR TITLE
Added base MvwFieldEditor.

### DIFF
--- a/src/org/dmd/dmt/client/editors/DMTBasicObjectField.java
+++ b/src/org/dmd/dmt/client/editors/DMTBasicObjectField.java
@@ -209,4 +209,10 @@ public class DMTBasicObjectField implements DmcPresentationIF {
 		throw(new IllegalStateException("delValue not implemented for attribute of value type: " + attribute.getAttributeInfo().valueType));
 	}
 
+	@Override
+	public boolean isValid() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 }

--- a/src/org/dmd/mvw/client/mvwforms/base/MvwFieldEditor.java
+++ b/src/org/dmd/mvw/client/mvwforms/base/MvwFieldEditor.java
@@ -1,0 +1,123 @@
+package org.dmd.mvw.client.mvwforms.base;
+
+import org.dmd.dmc.DmcObject;
+import org.dmd.dmc.presentation.DmcAdapterIF;
+import org.dmd.dmc.presentation.DmcPresentationIF;
+import org.dmd.dmc.presentation.DmcPresentationTrackerIF;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ * The creation of forms and binding them to DMOs is based on the the DmcPresentationIF.
+ * Many of the basic methods required by that interface require information that would
+ * have to be duplicated in each editor implementation. The MvwFieldEditor 
+ */
+abstract public class MvwFieldEditor implements DmcPresentationIF, IsWidget {
+	
+	// Our Unique ID assigned by the tracker
+	protected int						ID;
+	
+	// Whether or not we're mandatory
+	protected boolean 					mandatory;
+	
+	// Our attribute value adapter that also contains the original value (if any)
+	protected DmcAdapterIF				adapter;
+
+	// The thing that may be tracking our state of readiness
+	protected DmcPresentationTrackerIF	tracker;
+	
+	// This is only set if we're handling an indexed attribute, otherwise it's -1
+	protected int						attrIndex;
+	
+	// The label to be used for this field
+	protected String						label;
+	
+	// The object being edited
+	protected DmcObject					DMO;
+	
+	public MvwFieldEditor() {
+		attrIndex = -1;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public String getLabel() {
+		return(label);
+	}
+
+//	public void setToolTip(String tooltip);
+
+//	public void setMandatory(boolean mandatory) {
+//		this.mandatory = mandatory;
+//	}
+
+//	public void setReadOnly(boolean readonly);
+
+//  Not overloaded because you usually want to populate your display widget with the value
+//  that's in the adapter.
+//	public void setAdapter(DmcAdapterIF adapter);
+
+	@Override
+	public DmcAdapterIF getAdapter() {
+		return(adapter);
+	}
+
+//	public boolean isReady();
+
+	/**
+	 * Sets the presentation tracker and the unique identifier for this editor.
+	 */
+	public void setTracker(DmcPresentationTrackerIF t, int id) {
+		tracker = t;
+		ID = id;
+	}
+
+	/**
+	 * Returns the identifier by which the presentation tracker tracks this editor.
+	 */
+	public int getID() {
+		return(ID);
+	}
+
+//	public void resetToExisting();
+
+//	public boolean valueChanged();
+	
+//	public void setEnabled(boolean flag);
+
+	/**
+	 * You may need to override this since some value types aren't supported as indexed values.
+	 */
+	public void setValueIndex(int index) {
+		attrIndex = index;
+	}
+
+	/**
+	 * Sets the object being edited.
+	 */
+	public void setDMO(DmcObject dmo) {
+		DMO = dmo;
+	}
+
+	/**
+	 * Gets the object being edited.
+	 */
+	public DmcObject getDMO() {
+		return(DMO);
+	}
+	
+	///////////////////////////////////////////////////////////////////////////
+	
+	/**
+	 * A cheap mechanism for debugging your editors.
+	 * @param msg
+	 */
+	protected void DEBUG(String msg){
+		if (tracker.debug())
+			System.out.println(msg);
+	}
+
+
+}

--- a/src/org/dmd/mvw/tools/mvwgenerator/extended/RunContextItem.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/extended/RunContextItem.java
@@ -418,8 +418,10 @@ public class RunContextItem extends RunContextItemDMW {
 		}
 		
 		if (presenter != null){
-			if (presenter.isCodeSplit())
+			if (presenter.isCodeSplit()) {
 				im.addImport(presenter.getAsyncImport(), "Asynchronous creation of " + presenter.getPresenterName());
+				im.addImport(getUseClass(), "Used by " + getItemName());
+			}
 			else
 				im.addImport(getUseClass(), "Used by " + getItemName());
 		}

--- a/src/org/dmd/mvw/tools/mvwgenerator/util/ActivityFormatter.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/util/ActivityFormatter.java
@@ -54,7 +54,7 @@ public class ActivityFormatter {
     	
     	if (onDemand){
         	out.write("\n");
-        	out.write("    MvwRunContextIF runcontext;\n");
+        	out.write("    protected final MvwRunContextIF runcontext;\n");
     	}
 
     	out.write("\n");


### PR DESCRIPTION
The base field editor takes care of a variety of functionality that is
common across field editors.

Run context item was missing an import required by the presenter base
implementation for instantiating other code split presenters.

Updated the DMTBasicObjectField to add new isValid() method for
presenters.

Scope adjust for generated activities using the run context.