### PR TITLE
Mechanisms to support auto population of forms.

### DIFF
--- a/dark-matter-mvw DMO.launch
+++ b/dark-matter-mvw DMO.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/dark-matter-data/src/org/dmd/dms/tools/dmogenerator/DmoGeneratorMain.java"/>
+<listEntry value="/dark-matter-mvw"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
+<listEntry value="4"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>

--- a/src/org/dmd/mvw/client/mvwforms/base/MvwFormBindingIF.java
+++ b/src/org/dmd/mvw/client/mvwforms/base/MvwFormBindingIF.java
@@ -1,0 +1,24 @@
+package org.dmd.mvw.client.mvwforms.base;
+
+import java.util.Iterator;
+
+import org.dmd.dmc.presentation.DmcPresentationIF;
+
+/**
+ * The MvwFormBindingIF is implemented by classes generated via the FormBindingDefinition
+ * specification mechanisms.
+ */
+public interface MvwFormBindingIF {
+
+	/**
+	 * @return the label width.
+	 */
+	public Integer getLabelWidth();
+	
+	/**
+	 * @return the editors associated with this form binding.
+	 */
+	public Iterator<DmcPresentationIF> getEditors();
+	
+
+}

--- a/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/attributes.dmd
+++ b/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/attributes.dmd
@@ -810,6 +810,11 @@ type			String
 description		The text to be displayed when something, for instance an editor,
  doesn't have a value yet.
 
+AttributeDefinition
+name			labelWidth
+dmdID			109
+type			Integer
+description		The width of the labels associated with a form binding.
 
 //AttributeDefinition
 //name			mandatoryStyle

--- a/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd
+++ b/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd
@@ -445,6 +445,7 @@ must			editObject
 must			editField
 may				useI18NConfig
 may				tipsFromI18N
+may				labelWidth
 description		The FormBinding class allows for the definition of bindings between DMO attributes
  and the editors that will be used to display and edit their values. 
 

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/MvwSchemaAG.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/MvwSchemaAG.java
@@ -148,6 +148,7 @@ public class MvwSchemaAG extends SchemaDefinition {
     public static AttributeDefinition _accessGenerator;
     public static AttributeDefinition _propertyAccessName;
     public static AttributeDefinition _emptyText;
+    public static AttributeDefinition _labelWidth;
 
     public static TypeDefinition _EventWithArgs;
     public static TypeDefinition _MethodWithArgs;
@@ -196,6 +197,7 @@ public class MvwSchemaAG extends SchemaDefinition {
 
             initClasses();
             initAttributes1();
+            initAttributes2();
             initTypes();
             initComplexTypes();
             initActions();
@@ -735,7 +737,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _FormBindingDefinitionOBJ.setDmdID("1623");
             _FormBindingDefinitionOBJ.setClassType("STRUCTURAL");
             _FormBindingDefinitionOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _FormBindingDefinitionOBJ.setLineNumber("450");
+            _FormBindingDefinitionOBJ.setLineNumber("451");
             _FormBindingDefinitionOBJ.setIsNamedBy("mvw.bindingName");
             _FormBindingDefinitionOBJ.addDescription("The FormBinding class allows for the definition of bindings between DMO attributes\n and the editors that will be used to display and edit their values.");
             _FormBindingDefinitionOBJ.setUseWrapperType("EXTENDED");
@@ -747,6 +749,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _FormBindingDefinitionOBJ.addMay("mvw.strictlyChecked");
             _FormBindingDefinitionOBJ.addMay("mvw.useI18NConfig");
             _FormBindingDefinitionOBJ.addMay("mvw.tipsFromI18N");
+            _FormBindingDefinitionOBJ.addMay("mvw.labelWidth");
             _FormBindingDefinitionOBJ.setDmwIteratorImport("org.dmd.mvw.tools.mvwgenerator.generated.dmw.FormBindingDefinitionIterableDMW");
             _FormBindingDefinitionOBJ.setDmwIteratorClass("FormBindingDefinitionIterableDMW");
             _FormBindingDefinitionOBJ.setDmtREFImport("org.dmd.mvw.tools.mvwgenerator.generated.types.FormBindingDefinitionREF");
@@ -761,7 +764,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _FieldEditorDefinitionOBJ.setDmdID("1624");
             _FieldEditorDefinitionOBJ.setClassType("STRUCTURAL");
             _FieldEditorDefinitionOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _FieldEditorDefinitionOBJ.setLineNumber("471");
+            _FieldEditorDefinitionOBJ.setLineNumber("472");
             _FieldEditorDefinitionOBJ.setIsNamedBy("mvw.editorName");
             _FieldEditorDefinitionOBJ.addDescription("Way too long!");
             _FieldEditorDefinitionOBJ.setUseWrapperType("EXTENDED");
@@ -784,7 +787,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _FormImplementationConfigOBJ.setDmdID("1625");
             _FormImplementationConfigOBJ.setClassType("STRUCTURAL");
             _FormImplementationConfigOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _FormImplementationConfigOBJ.setLineNumber("483");
+            _FormImplementationConfigOBJ.setLineNumber("484");
             _FormImplementationConfigOBJ.setIsNamedBy("mvw.configName");
             _FormImplementationConfigOBJ.addDescription("The");
             _FormImplementationConfigOBJ.setUseWrapperType("EXTENDED");
@@ -805,7 +808,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _EnumMappingOBJ.setDmdID("1626");
             _EnumMappingOBJ.setClassType("STRUCTURAL");
             _EnumMappingOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _EnumMappingOBJ.setLineNumber("510");
+            _EnumMappingOBJ.setLineNumber("511");
             _EnumMappingOBJ.setIsNamedBy("mvw.mappingName");
             _EnumMappingOBJ.addDescription("Way too long!");
             _EnumMappingOBJ.setUseWrapperType("EXTENDED");
@@ -832,7 +835,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _EnumMappingGeneratorOBJ.setDmdID("1627");
             _EnumMappingGeneratorOBJ.setClassType("STRUCTURAL");
             _EnumMappingGeneratorOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _EnumMappingGeneratorOBJ.setLineNumber("522");
+            _EnumMappingGeneratorOBJ.setLineNumber("523");
             _EnumMappingGeneratorOBJ.setIsNamedBy("meta.camelCaseName");
             _EnumMappingGeneratorOBJ.addDescription("The EnumMappingGenerator definition allows for the specification of code\n generation extension that generates enum mapping code for a particular widget set.");
             _EnumMappingGeneratorOBJ.setUseWrapperType("EXTENDED");
@@ -853,7 +856,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _PropertyAccessGeneratorOBJ.setDmdID("1628");
             _PropertyAccessGeneratorOBJ.setClassType("STRUCTURAL");
             _PropertyAccessGeneratorOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _PropertyAccessGeneratorOBJ.setLineNumber("535");
+            _PropertyAccessGeneratorOBJ.setLineNumber("536");
             _PropertyAccessGeneratorOBJ.setIsNamedBy("meta.camelCaseName");
             _PropertyAccessGeneratorOBJ.addDescription("The PropertyAccessGenerator allows for the specification of the code\n generation extension that generates property access code mechanisms for a particular\n widget set.");
             _PropertyAccessGeneratorOBJ.setUseWrapperType("EXTENDED");
@@ -874,7 +877,7 @@ public class MvwSchemaAG extends SchemaDefinition {
             _PropertyAccessOBJ.setDmdID("1629");
             _PropertyAccessOBJ.setClassType("STRUCTURAL");
             _PropertyAccessOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/classes.dmd");
-            _PropertyAccessOBJ.setLineNumber("549");
+            _PropertyAccessOBJ.setLineNumber("550");
             _PropertyAccessOBJ.setIsNamedBy("mvw.propertyAccessName");
             _PropertyAccessOBJ.addDescription("The PropertyAccess class allows for the specification of a set of classes\n for which you'd like to invoke the specified property access generator that creates\n property access mechanisms.");
             _PropertyAccessOBJ.setUseWrapperType("EXTENDED");
@@ -2231,6 +2234,22 @@ public class MvwSchemaAG extends SchemaDefinition {
             _emptyTextOBJ.setLineNumber("812");
             _emptyText.setDefinedIn(this);
             addAttributeDefList(_emptyText);
+
+    }
+
+    private void initAttributes2() throws DmcValueException {
+// Generated from: org.dmd.dmg.util.SchemaFormatter.getObjectAsCode(SchemaFormatter.java:585)
+            AttributeDefinitionDMO _labelWidthOBJ = new AttributeDefinitionDMO();
+            _labelWidth = new AttributeDefinition(_labelWidthOBJ);
+            _labelWidthOBJ.addDescription("The width of the labels associated with a form binding.");
+            _labelWidthOBJ.setName("labelWidth");
+            _labelWidthOBJ.setDmdID("909");
+            _labelWidthOBJ.setType("meta.Integer");
+            _labelWidthOBJ.setFile("/src/org/dmd/mvw/tools/mvwgenerator/dmdconfig/v0dot1/attributes.dmd");
+            _labelWidthOBJ.setDotName("mvw.labelWidth.AttributeDefinition");
+            _labelWidthOBJ.setLineNumber("818");
+            _labelWidth.setDefinedIn(this);
+            addAttributeDefList(_labelWidth);
 
     }
 

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/FormBindingDefinitionDMO.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/FormBindingDefinitionDMO.java
@@ -30,6 +30,7 @@ import org.dmd.dms.generated.types.ClassDefinitionREF;                          
 import org.dmd.dms.generated.types.DmcTypeBooleanSV;                                  // Required type - (GenUtility.java:339)
 import org.dmd.dms.generated.types.DmcTypeCamelCaseNameSV;                            // Required type - (GenUtility.java:339)
 import org.dmd.dms.generated.types.DmcTypeClassDefinitionREFSV;                       // Reference type - (GenUtility.java:311)
+import org.dmd.dms.generated.types.DmcTypeIntegerSV;                                  // Required type - (GenUtility.java:339)
 import org.dmd.dms.generated.types.DmcTypeModifierMV;                                 // Required for MODREC constructor - (GenUtility.java:230)
 import org.dmd.mvw.tools.mvwgenerator.generated.dmo.I18NConfigDMO;                    // Type specific set/add - (GenUtility.java:318)
 import org.dmd.mvw.tools.mvwgenerator.generated.dmo.MvwDefinitionDMO;                 // Base class - (GenUtility.java:367)
@@ -295,6 +296,56 @@ public class FormBindingDefinitionDMO  extends MvwDefinitionDMO  implements DmcN
     // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:902)
     public void remTipsFromI18N(){
          rem(MvwDMSAG.__tipsFromI18N);
+    }
+
+    // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:789)
+    public Integer getLabelWidth(){
+        DmcTypeIntegerSV attr = (DmcTypeIntegerSV) get(MvwDMSAG.__labelWidth);
+        if (attr == null)
+            return(null);
+
+        return(attr.getSV());
+    }
+
+    /**
+     * Sets labelWidth to the specified value.
+     * @param value Integer
+     */
+    // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:829)
+    public void setLabelWidth(Integer value) {
+        DmcAttribute<?> attr = get(MvwDMSAG.__labelWidth);
+        if (attr == null)
+            attr = new DmcTypeIntegerSV(MvwDMSAG.__labelWidth);
+        
+        try{
+            attr.set(value);
+            set(MvwDMSAG.__labelWidth,attr);
+        }
+        catch(DmcValueException ex){
+            throw(new IllegalStateException("The type specific set() method shouldn't throw exceptions!",ex));
+        }
+    }
+
+    /**
+     * Sets labelWidth to the specified value.
+     * @param value A value compatible with DmcTypeIntegerSV
+     */
+    // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:882)
+    public void setLabelWidth(Object value) throws DmcValueException {
+        DmcTypeIntegerSV attr  = (DmcTypeIntegerSV) get(MvwDMSAG.__labelWidth);
+        if (attr == null)
+            attr = new DmcTypeIntegerSV(MvwDMSAG.__labelWidth);
+        
+        attr.set(value);
+        set(MvwDMSAG.__labelWidth,attr);
+    }
+
+    /**
+     * Removes the labelWidth attribute value.
+     */
+    // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:902)
+    public void remLabelWidth(){
+         rem(MvwDMSAG.__labelWidth);
     }
 
     // org.dmd.dms.util.GenUtility.formatSV(GenUtility.java:789)

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAG.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAG.java
@@ -88,6 +88,7 @@ public class MvwDMSAG implements DmcCompactSchemaIF {
     public final static DmcAttributeInfo __instantiatesView = new DmcAttributeInfo("mvw", "instantiatesView", 862, "View", ValueTypeEnum.MULTI, DataTypeEnum.PERSISTENT, 0, false);
     public final static DmcAttributeInfo __itemName = new DmcAttributeInfo("mvw", "itemName", 827, "CamelCaseName", ValueTypeEnum.SINGLE, DataTypeEnum.PERSISTENT, 0, false);
     public final static DmcAttributeInfo __itemOrder = new DmcAttributeInfo("mvw", "itemOrder", 829, "Integer", ValueTypeEnum.SINGLE, DataTypeEnum.PERSISTENT, 0, false);
+    public final static DmcAttributeInfo __labelWidth = new DmcAttributeInfo("mvw", "labelWidth", 909, "Integer", ValueTypeEnum.SINGLE, DataTypeEnum.PERSISTENT, 0, false);
     public final static DmcAttributeInfo __local = new DmcAttributeInfo("mvw", "local", 832, "Event", ValueTypeEnum.TREESET, DataTypeEnum.PERSISTENT, 0, false);
     public final static DmcAttributeInfo __localEvent = new DmcAttributeInfo("mvw", "localEvent", 814, "EventWithArgs", ValueTypeEnum.SINGLE, DataTypeEnum.PERSISTENT, 0, false);
     public final static DmcAttributeInfo __managesView = new DmcAttributeInfo("mvw", "managesView", 841, "View", ValueTypeEnum.MULTI, DataTypeEnum.PERSISTENT, 0, false);

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAGAMAP.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAGAMAP.java
@@ -68,6 +68,7 @@ public class MvwDMSAGAMAP {
         _SmAp.put(MvwDMSAG.__instantiatesView.id,MvwDMSAG.__instantiatesView);
         _SmAp.put(MvwDMSAG.__itemName.id,MvwDMSAG.__itemName);
         _SmAp.put(MvwDMSAG.__itemOrder.id,MvwDMSAG.__itemOrder);
+        _SmAp.put(MvwDMSAG.__labelWidth.id,MvwDMSAG.__labelWidth);
         _SmAp.put(MvwDMSAG.__local.id,MvwDMSAG.__local);
         _SmAp.put(MvwDMSAG.__localEvent.id,MvwDMSAG.__localEvent);
         _SmAp.put(MvwDMSAG.__managesView.id,MvwDMSAG.__managesView);

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAG_INIT_1.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/dmo/MvwDMSAG_INIT_1.java
@@ -315,6 +315,7 @@ public class MvwDMSAG_INIT_1 {
         MvwDMSAG.__FormBindingDefinition.addMust(MvwDMSAG.__editObject);
         MvwDMSAG.__FormBindingDefinition.addMay(MetaDMSAG.__description);
         MvwDMSAG.__FormBindingDefinition.addMay(MetaDMSAG.__file);
+        MvwDMSAG.__FormBindingDefinition.addMay(MvwDMSAG.__labelWidth);
         MvwDMSAG.__FormBindingDefinition.addMay(MetaDMSAG.__lineNumber);
         MvwDMSAG.__FormBindingDefinition.addMay(MvwDMSAG.__strictlyChecked);
         MvwDMSAG.__FormBindingDefinition.addMay(MvwDMSAG.__tipsFromI18N);

--- a/src/org/dmd/mvw/tools/mvwgenerator/generated/dmw/FormBindingDefinitionDMW.java
+++ b/src/org/dmd/mvw/tools/mvwgenerator/generated/dmw/FormBindingDefinitionDMW.java
@@ -277,6 +277,37 @@ abstract public class FormBindingDefinitionDMW extends MvwDefinition implements 
     }
 
     // org.dmd.dmg.generators.BaseDMWGenerator.formatSV(BaseDMWGenerator.java:1474)
+    public Integer getLabelWidth(){
+        return(((FormBindingDefinitionDMO) core).getLabelWidth());
+    }
+
+    /**
+     * Sets labelWidth to the specified value.
+     * @param value A value compatible with DmcTypeInteger
+     */
+    // org.dmd.dmg.generators.BaseDMWGenerator.formatSV(BaseDMWGenerator.java:1584)
+    public void setLabelWidth(Object value) throws DmcValueException {
+        ((FormBindingDefinitionDMO) core).setLabelWidth(value);
+    }
+
+    /**
+     * Sets labelWidth to the specified value.
+     * @param value Integer
+     */
+    // org.dmd.dmg.generators.BaseDMWGenerator.formatSV(BaseDMWGenerator.java:1593)
+    public void setLabelWidth(Integer value){
+        ((FormBindingDefinitionDMO) core).setLabelWidth(value);
+    }
+
+    /**
+     * Removes the labelWidth attribute value.
+     */
+    // org.dmd.dmg.generators.BaseDMWGenerator.formatSV(BaseDMWGenerator.java:1619)
+    public void remLabelWidth(){
+        ((FormBindingDefinitionDMO) core).remLabelWidth();
+    }
+
+    // org.dmd.dmg.generators.BaseDMWGenerator.formatSV(BaseDMWGenerator.java:1474)
     public Boolean isStrictlyChecked(){
         return(((FormBindingDefinitionDMO) core).isStrictlyChecked());
     }


### PR DESCRIPTION
Form bindings now support an interface that allows implementation
specific forms to populate themselves with editors.

Also allows for label width support.