### PR TITLE
Allow for events against derived classes in CacheListenerManager

### DIFF
--- a/dark-matter-mvw - clean deploy.launch
+++ b/dark-matter-mvw - clean deploy.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="clean deploy"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:dark-matter-mvw}"/>
+</launchConfiguration>

--- a/dark-matter-mvw - local install - np GPG.launch
+++ b/dark-matter-mvw - local install - np GPG.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="install"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES">
+<listEntry value="gpg.skip=true"/>
+</listAttribute>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:dark-matter-mvw}"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.connectifex</groupId>
   <artifactId>dark-matter-mvw</artifactId>
-  <version>2.1.1</version>
+  <version>2.1.2</version>
   
   <!-- Even though the gwteventservice 1.1.1 dependency should be available from mvnrepository.com
   the dependency inclusion fails for some reason. It indicates that this is where the dependency
@@ -75,13 +75,13 @@
     <dependency>
       <groupId>com.connectifex</groupId>
       <artifactId>dark-matter-data</artifactId>
-      <version>3.1.1</version>
+      <version>3.1.2</version>
     </dependency>
     
     <dependency>
       <groupId>com.connectifex</groupId>
       <artifactId>dark-matter-data</artifactId>
-      <version>3.1.1</version>
+      <version>3.1.2</version>
 	  <classifier>sources</classifier>
     </dependency>
     

--- a/src/org/dmd/dmp/server/servlet/base/cache/CacheListenerManager.java
+++ b/src/org/dmd/dmp/server/servlet/base/cache/CacheListenerManager.java
@@ -128,16 +128,27 @@ public class CacheListenerManager {
 		synchronized (this) {
 			LinkedList<CacheListener> 	listeners = new LinkedList<CacheListener>();
 			ListenerSet<?>				listenerSet = null;
+			ListenerSet<?>				listenerSet2 = null;
 			
 			listeners.addAll(fullListeners.getListeners());
 			
 			ClassDefinition cd = (ClassDefinition) event.getSourceObjectClass();
 			
+			ClassDefinition cd2 = cd.getDerivedFrom();
+			
 			// Index listeners
 			listenerSet = indexListeners.get(cd.getClassInfo());
+			
 			if (listenerSet != null)
 				listeners.addAll(listenerSet.getListeners());
+	
+			if (cd2!=null) {
+				listenerSet2 = indexListeners.get(cd2.getClassInfo());
 			
+				if (listenerSet2 != null)
+				listeners.addAll(listenerSet2.getListeners());
+			}
+
 			return(listeners);			
 		}
 		


### PR DESCRIPTION
Include run configs to build locally without signing and to deploy

Uprev pom dependencies